### PR TITLE
Add game rules and commands for whether to randomize drops

### DIFF
--- a/src/main/java/org/steve/spigotsteve/SpigotSteve.java
+++ b/src/main/java/org/steve/spigotsteve/SpigotSteve.java
@@ -2,9 +2,12 @@ package org.steve.spigotsteve;
 
 
 import org.bukkit.GameRule;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.steve.spigotsteve.commands.RandomizationCommands;
 import org.steve.spigotsteve.events.DropEvent;
 
 
@@ -23,6 +26,8 @@ public final class SpigotSteve extends JavaPlugin {
         config.options().copyDefaults(true);
         saveConfig();
 
+        this.getCommand("spigotSteve").setExecutor(new RandomizationCommands(config));
+
         dropEvent = new DropEvent(config);
         getServer().getPluginManager().registerEvents(dropEvent, this);
 
@@ -34,4 +39,16 @@ public final class SpigotSteve extends JavaPlugin {
         HandlerList.unregisterAll(dropEvent);
     }
 
+
+
+//    @Override
+//    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+//
+//        if (command.getName().equalsIgnoreCase("spigotsteve")) {
+//            getLogger().info("SpigotSteve command executed. Rule is: " + args[0] + ", value entered is: " + args[1]);
+//        }
+//
+//        return false;
+//    }
+//
 }

--- a/src/main/java/org/steve/spigotsteve/SpigotSteve.java
+++ b/src/main/java/org/steve/spigotsteve/SpigotSteve.java
@@ -10,23 +10,30 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.steve.spigotsteve.commands.RandomizationCommands;
 import org.steve.spigotsteve.events.DropEvent;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
 
 public final class SpigotSteve extends JavaPlugin {
 
     private final FileConfiguration config = getConfig();
     public DropEvent dropEvent;
 
+    public final String[] spigotSteveRules = {"doBlockRandomDrops", "doEntityRandomDrops", "doPlayerRandomDrops"};
+
     @Override
     public void onEnable() {
         // Plugin startup logic
 
-        config.addDefault("doBlockRandomDrops", true);
-        config.addDefault("doEntityRandomDrops", true);
-        config.addDefault("doPlayerRandomDrops", true);
+        for (String rule : spigotSteveRules) {
+            config.addDefault(rule, true);
+        }
+
         config.options().copyDefaults(true);
         saveConfig();
 
-        this.getCommand("spigotSteve").setExecutor(new RandomizationCommands(config));
+        this.getCommand("spigotSteve").setExecutor(new RandomizationCommands(config, spigotSteveRules));
 
         dropEvent = new DropEvent(config);
         getServer().getPluginManager().registerEvents(dropEvent, this);
@@ -36,19 +43,15 @@ public final class SpigotSteve extends JavaPlugin {
     @Override
     public void onDisable() {
         // Plugin shutdown logic
+
+        saveConfig();
+
         HandlerList.unregisterAll(dropEvent);
     }
 
 
 
-//    @Override
-//    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-//
-//        if (command.getName().equalsIgnoreCase("spigotsteve")) {
-//            getLogger().info("SpigotSteve command executed. Rule is: " + args[0] + ", value entered is: " + args[1]);
-//        }
-//
-//        return false;
-//    }
-//
+
+
 }
+

--- a/src/main/java/org/steve/spigotsteve/SpigotSteve.java
+++ b/src/main/java/org/steve/spigotsteve/SpigotSteve.java
@@ -2,45 +2,29 @@ package org.steve.spigotsteve;
 
 
 import org.bukkit.GameRule;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.steve.spigotsteve.events.DropEvent;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
-
 
 public final class SpigotSteve extends JavaPlugin {
 
+    private final FileConfiguration config = getConfig();
     public DropEvent dropEvent;
 
-    public static GameRule DO_PLAYER_RANDOM_DROPS;
     @Override
     public void onEnable() {
         // Plugin startup logic
-        dropEvent = new DropEvent();
+
+        config.addDefault("doBlockRandomDrops", true);
+        config.addDefault("doEntityRandomDrops", true);
+        config.addDefault("doPlayerRandomDrops", true);
+        config.options().copyDefaults(true);
+        saveConfig();
+
+        dropEvent = new DropEvent(config);
         getServer().getPluginManager().registerEvents(dropEvent, this);
-
-//        DO_PLAYER_RANDOM_DROPS.getClass().getConstructor(new GameRule("", Boolean.class));
-
-        try {
-            Class[] ruleArgs = new Class[2];
-            ruleArgs[0] = String.class;
-            ruleArgs[1] = Class.class;
-            Constructor<GameRule> gameRuleConstructor = GameRule.class.getDeclaredConstructor(ruleArgs);
-            gameRuleConstructor.setAccessible(true);
-
-            DO_PLAYER_RANDOM_DROPS = gameRuleConstructor.newInstance("doPlayerRandomDrops", Boolean.class);
-        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            getLogger().info(e.toString());
-        }
-
-//        new GameRule<>("doPlayerRandomDrops", Boolean.class);
-        getLogger().info("***Game Rules: ***");
-        Arrays.stream(GameRule.values()).toList().forEach(rule -> {
-            getLogger().info(rule.getName());
-        });
 
     }
 
@@ -49,4 +33,5 @@ public final class SpigotSteve extends JavaPlugin {
         // Plugin shutdown logic
         HandlerList.unregisterAll(dropEvent);
     }
+
 }

--- a/src/main/java/org/steve/spigotsteve/SpigotSteve.java
+++ b/src/main/java/org/steve/spigotsteve/SpigotSteve.java
@@ -1,19 +1,47 @@
 package org.steve.spigotsteve;
 
 
+import org.bukkit.GameRule;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.steve.spigotsteve.events.DropEvent;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 
 
 public final class SpigotSteve extends JavaPlugin {
 
     public DropEvent dropEvent;
+
+    public static GameRule DO_PLAYER_RANDOM_DROPS;
     @Override
     public void onEnable() {
         // Plugin startup logic
         dropEvent = new DropEvent();
         getServer().getPluginManager().registerEvents(dropEvent, this);
+
+//        DO_PLAYER_RANDOM_DROPS.getClass().getConstructor(new GameRule("", Boolean.class));
+
+        try {
+            Class[] ruleArgs = new Class[2];
+            ruleArgs[0] = String.class;
+            ruleArgs[1] = Class.class;
+            Constructor<GameRule> gameRuleConstructor = GameRule.class.getDeclaredConstructor(ruleArgs);
+            gameRuleConstructor.setAccessible(true);
+
+            DO_PLAYER_RANDOM_DROPS = gameRuleConstructor.newInstance("doPlayerRandomDrops", Boolean.class);
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            getLogger().info(e.toString());
+        }
+
+//        new GameRule<>("doPlayerRandomDrops", Boolean.class);
+        getLogger().info("***Game Rules: ***");
+        Arrays.stream(GameRule.values()).toList().forEach(rule -> {
+            getLogger().info(rule.getName());
+        });
+
     }
 
     @Override

--- a/src/main/java/org/steve/spigotsteve/commands/RandomizationCommands.java
+++ b/src/main/java/org/steve/spigotsteve/commands/RandomizationCommands.java
@@ -5,13 +5,22 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 
+import java.util.Objects;
+import java.util.function.Function;
+
 import static org.bukkit.Bukkit.getLogger;
 
-public class RandomizationCommands  implements CommandExecutor {
+public class RandomizationCommands implements CommandExecutor {
 
     private final FileConfiguration fileConfig;
-    public RandomizationCommands(FileConfiguration config) {
+
+    private final String[] spigotSteveRules;
+
+
+
+    public RandomizationCommands(FileConfiguration config, String[] spigotSteveRules) {
         this.fileConfig = config;
+        this.spigotSteveRules = spigotSteveRules;
     }
 
     @Override
@@ -21,7 +30,17 @@ public class RandomizationCommands  implements CommandExecutor {
             if (args.length != 2) {
                 sendInputIncorrectMessage(sender);
             } else {
-                getLogger().info("SpigotSteve command executed. Rule is: " + args[0] + ", value entered is: " + args[1]);
+                if (args[1].equalsIgnoreCase("true") || args[1].equalsIgnoreCase("false")) {
+                    for (String rule : spigotSteveRules) {
+                        if (Objects.equals(args[0], rule)) {
+                            fileConfig.set(rule, Boolean.valueOf(args[1]));
+
+                        }
+                    }
+                }
+                else  {
+                    sendInputIncorrectMessage(sender);
+                }
             }
 
         }

--- a/src/main/java/org/steve/spigotsteve/commands/RandomizationCommands.java
+++ b/src/main/java/org/steve/spigotsteve/commands/RandomizationCommands.java
@@ -1,0 +1,36 @@
+package org.steve.spigotsteve.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import static org.bukkit.Bukkit.getLogger;
+
+public class RandomizationCommands  implements CommandExecutor {
+
+    private final FileConfiguration fileConfig;
+    public RandomizationCommands(FileConfiguration config) {
+        this.fileConfig = config;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+
+        if (command.getName().equalsIgnoreCase("spigotsteve")) {
+            if (args.length != 2) {
+                sendInputIncorrectMessage(sender);
+            } else {
+                getLogger().info("SpigotSteve command executed. Rule is: " + args[0] + ", value entered is: " + args[1]);
+            }
+
+        }
+
+
+        return false;
+    }
+
+    private void sendInputIncorrectMessage(CommandSender sender) {
+        sender.sendMessage("Error! Correct format for SpigotSteve GameRule commands is '/spigotSteve <rule> <true/false>'");
+    }
+}

--- a/src/main/java/org/steve/spigotsteve/events/DropEvent.java
+++ b/src/main/java/org/steve/spigotsteve/events/DropEvent.java
@@ -4,6 +4,7 @@ import org.bukkit.GameRule;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -15,11 +16,14 @@ import org.steve.spigotsteve.drops.RandomDrops;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import static org.bukkit.Bukkit.getLogger;
-import static org.bukkit.Bukkit.getRegistry;
+import static org.bukkit.Bukkit.*;
 
 public class DropEvent implements Listener {
 
+    FileConfiguration config;
+    public DropEvent(FileConfiguration config) {
+        this.config = config;
+    }
 
     @EventHandler
     public void blockDrop(BlockDropItemEvent event) {
@@ -37,10 +41,6 @@ public class DropEvent implements Listener {
         event.getItems().forEach(item -> {
             moddedLoot.add(item.getItemStack().getType());
         });
-
-
-//        if (event.getBlock().getBlockData().getAsString())
-//        getLogger().info(event.getBlock().getType().name());
 
 
         event.setCancelled(true);
@@ -90,11 +90,13 @@ public class DropEvent implements Listener {
         getLogger().info(event.getBlock().getType().name());
 
         if (event.getBlock().getType().name().equals("GRASS_BLOCK")) {
-            event.getBlock().getWorld().setGameRule(SpigotSteve.DO_PLAYER_RANDOM_DROPS, false);
+//            event.getBlock().getWorld().setGameRule(SpigotSteve.DO_PLAYER_RANDOM_DROPS, false);
             getLogger().info("Grass block matched!!");
+
         }
 
-        getLogger().info("Player random drops: " + event.getBlock().getWorld().getGameRuleValue(SpigotSteve.DO_PLAYER_RANDOM_DROPS));
+        getLogger().info("Block Random Drops: " + config.getBoolean("doBlockRandomDrops"));
+//        getLogger().info("Player random drops: " + event.getBlock().getWorld().getGameRuleValue(SpigotSteve.DO_PLAYER_RANDOM_DROPS));
 
 
 

--- a/src/main/java/org/steve/spigotsteve/events/DropEvent.java
+++ b/src/main/java/org/steve/spigotsteve/events/DropEvent.java
@@ -1,16 +1,22 @@
 package org.steve.spigotsteve.events;
 
+import org.bukkit.GameRule;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDropItemEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
+import org.steve.spigotsteve.SpigotSteve;
 import org.steve.spigotsteve.drops.RandomDrops;
 import java.util.ArrayList;
+import java.util.Arrays;
+
 import static org.bukkit.Bukkit.getLogger;
+import static org.bukkit.Bukkit.getRegistry;
 
 public class DropEvent implements Listener {
 
@@ -22,6 +28,7 @@ public class DropEvent implements Listener {
             RandomDrops.shuffleItems(event.getBlock().getWorld().getSeed());
         }
 
+
         ArrayList<Material> moddedLoot = new ArrayList<>();
 
         World world = event.getBlock().getWorld();
@@ -31,6 +38,9 @@ public class DropEvent implements Listener {
             moddedLoot.add(item.getItemStack().getType());
         });
 
+
+//        if (event.getBlock().getBlockData().getAsString())
+//        getLogger().info(event.getBlock().getType().name());
 
 
         event.setCancelled(true);
@@ -75,6 +85,22 @@ public class DropEvent implements Listener {
     }
 
 
+    @EventHandler
+    private void blockBreak(BlockBreakEvent event) {
+        getLogger().info(event.getBlock().getType().name());
+
+        if (event.getBlock().getType().name().equals("GRASS_BLOCK")) {
+            event.getBlock().getWorld().setGameRule(SpigotSteve.DO_PLAYER_RANDOM_DROPS, false);
+            getLogger().info("Grass block matched!!");
+        }
+
+        getLogger().info("Player random drops: " + event.getBlock().getWorld().getGameRuleValue(SpigotSteve.DO_PLAYER_RANDOM_DROPS));
+
+
+
+
+
+    }
 
 
 }

--- a/src/main/java/org/steve/spigotsteve/events/DropEvent.java
+++ b/src/main/java/org/steve/spigotsteve/events/DropEvent.java
@@ -25,6 +25,8 @@ public class DropEvent implements Listener {
         this.config = config;
     }
 
+    //TODO: Make drop randomization conditional based on spigotSteve gameRules
+
     @EventHandler
     public void blockDrop(BlockDropItemEvent event) {
 

--- a/src/main/java/org/steve/spigotsteve/events/DropEvent.java
+++ b/src/main/java/org/steve/spigotsteve/events/DropEvent.java
@@ -13,6 +13,7 @@ import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
 import org.steve.spigotsteve.SpigotSteve;
 import org.steve.spigotsteve.drops.RandomDrops;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -21,11 +22,12 @@ import static org.bukkit.Bukkit.*;
 public class DropEvent implements Listener {
 
     FileConfiguration config;
+
     public DropEvent(FileConfiguration config) {
         this.config = config;
     }
 
-    //TODO: Make drop randomization conditional based on spigotSteve gameRules
+    //TODO: Make drop randomization for Players conditional on spigotSteve gameRule.
 
     @EventHandler
     public void blockDrop(BlockDropItemEvent event) {
@@ -34,22 +36,23 @@ public class DropEvent implements Listener {
             RandomDrops.shuffleItems(event.getBlock().getWorld().getSeed());
         }
 
+        if (config.getBoolean("doBlockRandomDrops")) {
 
-        ArrayList<Material> moddedLoot = new ArrayList<>();
+            ArrayList<Material> moddedLoot = new ArrayList<>();
 
-        World world = event.getBlock().getWorld();
-        Location location = event.getBlock().getLocation();
+            World world = event.getBlock().getWorld();
+            Location location = event.getBlock().getLocation();
 
-        event.getItems().forEach(item -> {
-            moddedLoot.add(item.getItemStack().getType());
-        });
+            event.getItems().forEach(item -> {
+                moddedLoot.add(item.getItemStack().getType());
+            });
 
+            event.setCancelled(true);
 
-        event.setCancelled(true);
-
-        moddedLoot.forEach(vanillaDrop -> {
-            dropSomething(location, world, vanillaDrop);
-        });
+            moddedLoot.forEach(vanillaDrop -> {
+                dropSomething(location, world, vanillaDrop);
+            });
+        }
     }
 
     @EventHandler
@@ -58,22 +61,27 @@ public class DropEvent implements Listener {
             RandomDrops.shuffleItems(event.getEntity().getWorld().getSeed());
         }
 
-        World world = event.getEntity().getWorld();
-        Location location = event.getEntity().getLocation();
+        if (config.getBoolean("doEntityRandomDrops")) {
 
-        ArrayList<Material> moddedLoot = new ArrayList<>();
+            World world = event.getEntity().getWorld();
+            Location location = event.getEntity().getLocation();
 
-        event.getDrops().forEach(item -> {
-            for (int i = 0; i < item.getAmount(); i++) {
-                moddedLoot.add(item.getType());
-            }
-        });
+            ArrayList<Material> moddedLoot = new ArrayList<>();
 
-        event.getDrops().clear();
+            event.getDrops().forEach(item -> {
+                for (int i = 0; i < item.getAmount(); i++) {
+                    moddedLoot.add(item.getType());
+                }
+            });
 
-        moddedLoot.forEach(vanillaDrop -> {
-            dropSomething(location, world, vanillaDrop);
-        });
+            event.getDrops().clear();
+
+            moddedLoot.forEach(vanillaDrop -> {
+                dropSomething(location, world, vanillaDrop);
+            });
+        }
+
+
     }
 
 
@@ -99,9 +107,6 @@ public class DropEvent implements Listener {
 
         getLogger().info("Block Random Drops: " + config.getBoolean("doBlockRandomDrops"));
 //        getLogger().info("Player random drops: " + event.getBlock().getWorld().getGameRuleValue(SpigotSteve.DO_PLAYER_RANDOM_DROPS));
-
-
-
 
 
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,5 +5,6 @@ api-version: '1.20'
 commands:
   spigotSteve:
     description: GameRules to customize drop randomization.
-    usage: /<spigotSteve> <rule> <true/false>
+    usage: "Usage: /<spigotSteve> [rule] [true|false]"
+
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,6 @@ api-version: '1.20'
 commands:
   spigotSteve:
     description: GameRules to customize drop randomization.
-    usage: "Usage: /<spigotSteve> [rule] [true|false]"
+    usage: "Usage: /<spigotSteve> <rule> <true|false>"
 
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,4 +2,8 @@ name: SpigotSteve
 version: '${version}'
 main: org.steve.spigotsteve.SpigotSteve
 api-version: '1.20'
+commands:
+  spigotSteve:
+    description: GameRules to customize drop randomization.
+    usage: /<spigotSteve> <rule> <true/false>
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,4 @@ name: SpigotSteve
 version: '${version}'
 main: org.steve.spigotsteve.SpigotSteve
 api-version: '1.20'
+


### PR DESCRIPTION
- Experiment with bukkit GameRules and using reflection to add new gamerules to map
- Instead, create booleans to be saved in config file to act as new game rules
- Create commands for turning new game rules on/off
- Make drops from blocks and entities conditional on new game rules